### PR TITLE
- disable mdadm auto assemble during DASD dialog

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 08 14:01:56 CEST 2018 - aschnell@suse.com
+
+- disable mdadm auto assemble during DASD dialog (bsc#1089645)
+- 4.0.4
+
+-------------------------------------------------------------------
 Tue Mar 20 15:12:15 UTC 2018 - jreidinger@suse.com
 
 - Improve error reporting and logging when underlying scripts

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -31,6 +31,11 @@ BuildRequires:	yast2-ruby-bindings >= 3.1.7
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildRequires:	update-desktop-files
+
+# Y2Storage::Inhibitors
+BuildRequires: yast2-storage-ng >= 4.0.175
+Requires:      yast2-storage-ng >= 4.0.175
+
 ExclusiveArch:  s390 s390x
 Requires:	yast2
 Requires:	yast2-ruby-bindings >= 3.1.7

--- a/src/include/s390/dasd/wizards.rb
+++ b/src/include/s390/dasd/wizards.rb
@@ -24,6 +24,9 @@
 # Summary:	Wizards definitions
 # Authors:	Jiri Srain <jsrain@suse.cz>
 #
+
+require "y2storage/inhibitors"
+
 module Yast
   module S390DasdWizardsInclude
     def initialize_s390_dasd_wizards(include_target)
@@ -80,7 +83,13 @@ module Yast
       Wizard.CreateDialog
       Wizard.SetDesktopIcon("dasd")
 
-      ret = Sequencer.Run(aliases, sequence)
+      begin
+        inhibitors = Y2Storage::Inhibitors.new
+        inhibitors.inhibit
+        ret = Sequencer.Run(aliases, sequence)
+      ensure
+        inhibitors.uninhibit
+      end
 
       Wizard.CloseDialog
 


### PR DESCRIPTION
For https://trello.com/c/sBGUAwc8/374-sles15-p2-1089645-build5671s390x-unable-to-format-dasd-which-contains-a-linux-raid-partition.