### PR TITLE
Avoid hanging YaST when try to deactivate a DASD in use

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 21 11:43:00 UTC 2018 - dgonzalez@suse.com
+
+- Avoid hanging YaST when try to deactivate a DASD in use
+  (bsc#1091797)
+- 4.0.5
+
+-------------------------------------------------------------------
 Mon Aug 20 09:20:22 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -466,99 +466,55 @@ module Yast
       when 0
 
       when 1
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: sysfs not mounted."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: sysfs not mounted."), channel))
       when 2
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: Invalid status for <online>."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: Invalid status for <online>."), channel))
       when 3
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: No device found for <ccwid>."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: No device found for <ccwid>."), channel))
       when 4
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: Could not change state of the device."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: Could not change state of the device."), channel))
       when 5
         # https://bugzilla.novell.com/show_bug.cgi?id=446998#c15
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: Device is not a DASD."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: Device is not a DASD."), channel))
       when 6
         # https://bugzilla.novell.com/show_bug.cgi?id=446998#c15
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: Could not load module."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: Could not load module."), channel))
       when 7
         # http://bugzilla.novell.com/show_bug.cgi?id=561876#c8
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: Failed to activate DASD."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: Failed to activate DASD."), channel))
       when 8
         # http://bugzilla.novell.com/show_bug.cgi?id=561876#c8
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification
-            _("%1: DASD is not formatted."),
-            channel
-          )
-        )
+        # error report, %1 is device identification
+        Report.Error(Builtins.sformat(_("%1: DASD is not formatted."), channel))
       when 16
         # https://bugzilla.suse.com/show_bug.cgi?id=1091797#c8
-        details = []
-        details << "Stdout:\n #{ret["stdout"]}" unless ret["stdout"].to_s.empty?
-        details << "Stderr:\n #{ret["stderr"]}" unless ret["stderr"].to_s.empty?
         headline = _("Error: channel in use")
         # TRANSLATORS: error report, %1 is device identification
         message = Builtins.sformat(_("%1 DASD is in use and cannot be deactivated."), channel)
+        details = output_details(ret)
 
         if details.empty?
           Report.Error(message)
         else
-          message << "\n\n#{_("See the details for more info.")}"
-          Yast2::Popup.show(message, headline: headline, details: details.join("\n\n"))
+          message << "\n\n#{_("See details for more info.")}"
+          Yast2::Popup.show(message, headline: headline, details: details)
         end
       else
-        Report.Error(
-          Builtins.sformat(
-            # error report, %1 is device identification, %2 is integer code
-            _("%1: Unknown error %2.\nstderr:%3\nstdout:%4"),
-            channel,
-            ret["exit"],
-            ret["stderr"],
-            ret["stdout"]
-          )
+        message = format(
+          # TRANSLATORS: error message, %channel is device identification, %code is an integer code
+          _("%{channel}: Unknown error %{code}\n\nSee details for more info."),
+          channel: channel,
+          code:    ret["exit"]
         )
+
+        Yast2::Popup.show(message, headline: _("Unknown error"), details: output_details(ret))
       end
 
       nil
@@ -870,6 +826,19 @@ module Yast
 
       stderr
     end
+  end
+
+  # Returns an string containing the available stdout and/or stderr
+  #
+  # @param ret [Hash]
+  # @return [String]
+  def output_details(ret)
+    output = {
+      stderr: ret["stderr"].to_s.strip,
+      stdout: ret["stdout"].to_s.strip
+    }
+
+    output.map { |k, v| "#{k}: #{v}" unless v.empty? }.compact.join("\n\n")
   end
 
   DASDController = DASDControllerClass.new

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -31,6 +31,25 @@ describe "Yast::DASDController" do
       subject.DeactivateDisk(channel, diagnose)
     end
 
+    context "whit unknown exit code" do
+      let(:command_result) do
+        {
+          "exit"   => exit_code,
+          "stderr" => "Warning: ECKD DASD 0.0.0150 is unknown!\n" \
+                      "The following unknown resources may be affected:\n" \
+                      "- Mount point /unknown\n",
+          "stdout" => "Continue with operation? (yes/no)"
+        }
+      end
+      let(:exit_code) { "unknown" }
+
+      it "reports an error with details" do
+        expect(Yast2::Popup).to receive(:show).with(anything, hash_including(:headline, :details))
+
+        subject.DeactivateDisk(channel, diagnose)
+      end
+    end
+
     context "when disk is being in use" do
       let(:exit_code) { 16 }
 

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -7,6 +7,65 @@ Yast.import "DASDController"
 describe "Yast::DASDController" do
   subject { Yast::DASDController }
 
+  describe "#DeactivateDisk" do
+    let(:channel) { "0.0.0160" }
+    let(:diagnose) { false }
+    let(:exit_code) { 0 }
+    let(:command_result) { { "exit" => exit_code } }
+
+    before do
+      allow(Yast::Report).to receive(:Error)
+      allow(Yast2::Popup).to receive(:show)
+      allow(Yast::SCR).to receive(:Execute).and_return(command_result)
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast.path(".probe.disk")).once
+        .and_return(load_data("probe_disk_dasd.yml"))
+
+      subject.ProbeDisks()
+    end
+
+    it "redirects output to /dev/null" do
+      expect(Yast::SCR).to receive(:Execute)
+        .with(anything, /\/sbin\/dasd_configure .* < \/dev\/null/)
+
+      subject.DeactivateDisk(channel, diagnose)
+    end
+
+    context "when disk is being in use" do
+      let(:exit_code) { 16 }
+
+      it "returns nil" do
+        expect(subject.DeactivateDisk(channel, diagnose)).to be_nil
+      end
+
+      context "and there are details to show" do
+        let(:command_result) do
+          {
+            "exit"   => exit_code,
+            "stderr" => "Warning: ECKD DASD 0.0.0150 is in use!\n" \
+                        "The following resources may be affected:\n" \
+                        "- Mount point /mnt\n",
+            "stdout" => "Continue with operation? (yes/no)"
+          }
+        end
+
+        it "reports an error with details" do
+          expect(Yast2::Popup).to receive(:show).with(anything, hash_including(:headline, :details))
+
+          subject.DeactivateDisk(channel, diagnose)
+        end
+      end
+
+      context "and there are not details to show" do
+        it "reports an error" do
+          expect(Yast::Report).to receive(:Error).with(/in use/)
+
+          subject.DeactivateDisk(channel, diagnose)
+        end
+      end
+    end
+  end
+
   describe "#IsAvailable" do
     it "returns true if .probe.disk contains DASDs" do
       expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1091797

### Problem

> When trying to deactivate a DASD using 'yast2 dasd' the UI hangs
without any error feedback

### Fix

Based on a [hack in the 8th comment](https://bugzilla.suse.com/show_bug.cgi?id=1091797#c8), it is avoided the YaST UI freeze, displaying to the user a Popup with details about what was wrong.

See screenshots attached.

![screenshot from 2018-09-21 13-16-16](https://user-images.githubusercontent.com/1691872/45880685-b7bf8880-bda0-11e8-8233-f88aa87a4ddd.png)

![screenshot from 2018-09-21 13-16-50](https://user-images.githubusercontent.com/1691872/45880700-bee69680-bda0-11e8-9611-343087269b33.png)

