### PR TITLE
I/O device pre-configuration

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb  5 12:44:58 UTC 2019 - jlopez@suse.com
+
+- Added new client for I/O devices pre-configuration (fate#326828).
+- 4.1.0
+
+-------------------------------------------------------------------
 Tue Oct 16 15:14:53 CEST 2018 - schubi@suse.de
 
 - Added license file to spec. 

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -65,6 +65,7 @@ rake install DESTDIR="%{buildroot}"
 %{yast_yncludedir}/s390/*
 %{yast_clientdir}/*.rb
 %{yast_moduledir}/*
+%{yast_dir}/lib
 %{yast_scrconfdir}/*.scr
 %{yast_desktopdir}/*.desktop
 %{yast_schemadir}/autoyast/rnc/*.rnc

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.0.5
+Version:        4.1.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_devices_preconf.rb
+++ b/src/clients/inst_devices_preconf.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2s390/clients/inst_devices_preconf"
+
+Y2S390::Clients::InstDevicesPreconf.new.run

--- a/src/lib/y2s390/clients/inst_devices_preconf.rb
+++ b/src/lib/y2s390/clients/inst_devices_preconf.rb
@@ -1,0 +1,91 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2s390/dialogs/devices_preconf"
+
+Yast.import "Kernel"
+Yast.import "Arch"
+Yast.import "GetInstArgs"
+
+module Y2S390
+  module Clients
+    # I/O device auto-configuration is a mechanism by which users can specify IDs
+    # and settings of I/O devices that should be automatically enabled.
+    #
+    # This client allows to trigger such mechanism.
+    class InstDevicesPreconf
+      include Yast::Logger
+
+      AUTOCONFIG_FILE = "/sys/firmware/sclp_sd/config/data".freeze
+
+      # @return [Symbol] :auto, :next, :back or :abort
+      def run
+        # :auto forwards the former action (:next or :back)
+        return :auto if skip?
+
+        result = dialog.run
+
+        disable_autoconfig if result == :next && !dialog.autoconfig?
+
+        result
+      end
+
+    private
+
+      # Whether this client should be skipped
+      #
+      # The client is skipped when the file with devices configuration
+      # does not exist or it has no content.
+      #
+      # @return [Boolean]
+      def skip?
+        missing_config_file? || empty_config_file?
+      end
+
+      # Whether the configuration file does not exist
+      #
+      # @return [Boolean]
+      def missing_config_file?
+        !File.exist?(AUTOCONFIG_FILE)
+      end
+
+      # Whether the configuration file has no content
+      #
+      # @return [Boolean]
+      def empty_config_file?
+        File.open(AUTOCONFIG_FILE, "rb") { |f| f.read(1).nil? }
+      end
+
+      # Dialog to select auto-configuration options
+      #
+      # @return [Dialogs::DevicesPreconf]
+      def dialog
+        @dialog ||= Dialogs::DevicesPreconf.new
+      end
+
+      # Adds a kernel parameter to disable devices auto-configuration
+      def disable_autoconfig
+        Yast::Kernel.AddCmdLine("rd.zdev", "no-auto")
+      end
+    end
+  end
+end

--- a/src/lib/y2s390/dialogs/devices_preconf.rb
+++ b/src/lib/y2s390/dialogs/devices_preconf.rb
@@ -1,0 +1,138 @@
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may
+# find current contact information at www.novell.com.
+
+require "ui/installation_dialog"
+require "yast2/execute"
+
+module Y2S390
+  module Dialogs
+    # Provides to the user the option to pre-configure devices for the installation
+    # process. It also allows to avoid devices auto-configuration for the installed
+    # system.
+    class DevicesPreconf < ::UI::InstallationDialog
+      def initialize
+        super
+
+        textdomain "s390"
+
+        @autoconfig = false
+      end
+
+      # Saves selected values when user goes next
+      #
+      # @see #save
+      def next_handler
+        save
+
+        super
+      end
+
+      # Directly loads auto-configuration when user selects the proper button
+      #
+      # @param input [Symbol]
+      def handle_event(input)
+        load_autoconfig if input == :load_autoconfig
+      end
+
+      # Whether the user selected auto-configuration checkbox
+      #
+      # @return [Boolean]
+      def autoconfig?
+        @autoconfig
+      end
+
+    private
+
+      def dialog_title
+        # TRANSLATORS: Title of the installation step to auto-configure devices.
+        _("I/0 Device Auto-configuration")
+      end
+
+      def dialog_content
+        MarginBox(
+          2, 1,
+          VBox(
+            Label(_("I/O device auto-configuration found.")),
+            load_autoconfig_button,
+            VSpacing(2),
+            Label(_("The button above will only affect the installation process.")),
+            autoconfig_checkbox
+          )
+        )
+      end
+
+      def help_text
+        # TRANSLATORS: Help text, where %{autoconfig_button} is replaced by the label of
+        # the button to load the auto-configuration, %{autoconfig_file} is replaced by a
+        # file path (e.g., /tmp/bar), and %{autoconfig_checkbox} is replaced by the label
+        # of the checkbox to avoid auto-configuration in the installed system.
+        format(
+          _(
+            "<p><b>%{autoconfig_button}</b>: loads I/O devices auto-configuration " \
+            "from %{autoconfig_file}.</p>" \
+            "<p><b>%{autoconfig_checkbox}</b>: when unchecked, the auto-configuration " \
+            "is not applied again for the installed system.</p>"
+          ),
+          autoconfig_button:   load_autoconfig_button_label,
+          autoconfig_file:     Clients::InstDevicesPreconf::AUTOCONFIG_FILE,
+          autoconfig_checkbox: autoconfig_checkbox_label
+        )
+      end
+
+      def load_autoconfig_button
+        PushButton(Id(:load_autoconfig), load_autoconfig_button_label)
+      end
+
+      def load_autoconfig_button_label
+        # TRANSLATORS: Label of button to load devices auto-configuration.
+        _("Load Auto-configuration Now")
+      end
+
+      def autoconfig_checkbox(checked: true)
+        CheckBox(Id(:autoconfig), autoconfig_checkbox_label, checked)
+      end
+
+      def autoconfig_checkbox_label
+        # TRANSLATORS: Label of checkbox to disable auto-configuration for the installed system.
+        _("Apply Auto-configuration Also To The Installed System")
+      end
+
+      # Tries to load auto-configuration
+      #
+      # An error popup is shown when the command fails, see Yast::Execute#locally.
+      def load_autoconfig
+        Yast::Execute.locally(
+          "chzdev", "--import", "/sys/firmware/sclp_sd/config/data",
+          "--force", "--yes", "--no-root-update", "--no-settle", "--active", "--quiet"
+        )
+      end
+
+      def save
+        @autoconfig = widget_value(:autoconfig)
+      end
+
+      # Helper to get widget value
+      def widget_value(id, attr: :Value)
+        Yast::UI.QueryWidget(Id(id), attr)
+      end
+    end
+  end
+end

--- a/test/y2s390/clients/inst_devices_preconf_test.rb
+++ b/test/y2s390/clients/inst_devices_preconf_test.rb
@@ -1,0 +1,144 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper.rb"
+require "y2s390/clients/inst_devices_preconf"
+
+describe Y2S390::Clients::InstDevicesPreconf do
+  subject { described_class.new }
+
+  describe "#run" do
+    shared_examples "no action" do
+      it "does not add kernel paramaters" do
+        expect(Yast::Kernel).to_not receive(:AddCmdLine)
+
+        subject.run
+      end
+    end
+
+    shared_examples "forward action" do
+      include_examples "no action"
+
+      it "returns :auto" do
+        expect(subject.run).to eq(:auto)
+      end
+    end
+
+    before do
+      allow(File).to receive(:exist?).with("/sys/firmware/sclp_sd/config/data")
+        .and_return(exist_config_file)
+
+      allow(File).to receive(:open).with("/sys/firmware/sclp_sd/config/data", any_args)
+        .and_return(empty_config_file)
+
+      allow(Y2S390::Dialogs::DevicesPreconf).to receive(:new).and_return(dialog)
+
+      allow(dialog).to receive(:run).and_return(dialog_result)
+
+      allow(dialog).to receive(:autoconfig?).and_return(dialog_autoconf)
+    end
+
+    let(:exist_config_file) { nil }
+
+    let(:empty_config_file) { nil }
+
+    let(:dialog) { instance_double(Y2S390::Dialogs::DevicesPreconf) }
+
+    let(:dialog_result) { nil }
+
+    let(:dialog_autoconf) { nil }
+
+    context "when the config file does not exist" do
+      let(:exist_config_file) { false }
+
+      include_examples "forward action"
+    end
+
+    context "when the config file exists" do
+      let(:exist_config_file) { true }
+
+      context "and has no content" do
+        let(:empty_config_file) { true }
+
+        include_examples "forward action"
+      end
+
+      context "and has content" do
+        let(:empty_config_file) { false }
+
+        it "opens a dialog to pre-configure devices" do
+          expect(dialog).to receive(:run)
+
+          subject.run
+        end
+
+        context "and the user aborts" do
+          let(:dialog_result) { :abort }
+
+          include_examples "no action"
+
+          it "returns :abort" do
+            expect(subject.run).to eq(:abort)
+          end
+        end
+
+        context "and the user goes back" do
+          let(:dialog_result) { :back }
+
+          include_examples "no action"
+
+          it "returns :back" do
+            expect(subject.run).to eq(:back)
+          end
+        end
+
+        context "and the user goes next" do
+          let(:dialog_result) { :next }
+
+          context "and the auto-configuration option was selected" do
+            let(:dialog_autoconf) { true }
+
+            include_examples "no action"
+
+            it "returns :next" do
+              expect(subject.run).to eq(:next)
+            end
+          end
+
+          context "and the auto-configuration option was not selected" do
+            let(:dialog_autoconf) { false }
+
+            it "adds kernel paramater to not auto-configure devices" do
+              expect(Yast::Kernel).to receive(:AddCmdLine).with("rd.zdev", "no-auto")
+
+              subject.run
+            end
+
+            it "returns :next" do
+              expect(subject.run).to eq(:next)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/y2s390/dialogs/devices_preconf_test.rb
+++ b/test/y2s390/dialogs/devices_preconf_test.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper.rb"
+require "y2s390/dialogs/devices_preconf"
+
+Yast.import "UI"
+
+describe Y2S390::Dialogs::DevicesPreconf do
+  include Yast::UIShortcuts
+
+  def term_with_id(widget_id, content)
+    content.nested_find do |nested|
+      next unless nested.is_a?(Yast::Term)
+      nested.params.any? { |i| i.is_a?(Yast::Term) && i.value == :id && widget_id == i.params.first }
+    end
+  end
+
+  subject { described_class.new }
+
+  describe "#run" do
+    before do
+      allow(Yast::UI).to receive(:UserInput).and_return(*user_input)
+
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:autoconfig), :Value)
+        .and_return(marked_checkbox)
+    end
+
+    let(:user_input) { [:next] }
+
+    let(:content) { subject.send(:dialog_content) }
+
+    let(:marked_checkbox) { true }
+
+    it "contains a button to apply auto-configuration" do
+      expect(term_with_id(:load_autoconfig, content)).to_not be_nil
+    end
+
+    it "contains a checkbox to auto-configure devices in installed system" do
+      expect(term_with_id(:autoconfig, content)).to_not be_nil
+    end
+
+    it "marks the checkbox by default" do
+      widget = term_with_id(:autoconfig, content)
+
+      expect(widget.params.last).to eq(true)
+    end
+
+    context "when the user clicks the button to apply auto-configuration" do
+      let(:user_input) { [:load_autoconfig, :back] }
+
+      it "tries to load the auto-configuration with 'chzdev' command" do
+        expect(Yast::Execute).to receive(:locally).with("chzdev", any_args)
+
+        subject.run
+      end
+    end
+
+    context "when the user marks the checkbox" do
+      let(:marked_checkbox) { true }
+
+      context "and the user goes next" do
+        let(:user_input) { [:next] }
+
+        it "sets autoconfig to true" do
+          subject.run
+
+          expect(subject.autoconfig?).to eq(true)
+        end
+      end
+
+      context "and the user goes back" do
+        let(:user_input) { [:back] }
+
+        it "sets autoconfig to false" do
+          subject.run
+
+          expect(subject.autoconfig?).to eq(false)
+        end
+      end
+    end
+
+    context "when the user does not mark the checkbox" do
+      let(:marked_checkbox) { false }
+
+      context "and the user goes next" do
+        let(:user_input) { [:next] }
+
+        it "sets autoconfig to false" do
+          subject.run
+
+          expect(subject.autoconfig?).to eq(false)
+        end
+      end
+
+      context "and the user goes back" do
+        let(:user_input) { [:back] }
+
+        it "sets autoconfig to false" do
+          subject.run
+
+          expect(subject.autoconfig?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Problem

A new client needs to be added for the installation in s390. This client would allow to pre-configure I/O devices according to data from file `/sys/firmware/sclp_sd/config/data`. Skelcds need to be adapted to include this new client.

* https://fate.suse.com/326828
* https://trello.com/c/UMzHnQA9/601-5-fate326828-i-o-device-pre-configuration-installer-part

### Solution

A new client `inst_devices_preconf` is added.

### Testing

* Added unit tests.
* New client was manually tested.
* [Pending] Real test in s390 machine.

### Screenshots

It looks a little ugly because the client was launched locally without styles.

![virtualbox_opensuse tumbleweed_05_02_2019_15_09_38](https://user-images.githubusercontent.com/1112304/52282446-587da180-2958-11e9-8950-ff30787569fa.png)
