### PR TITLE
Fix bsc1134927 sort

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 16 11:27:09 CEST 2019 - aschnell@suse.com
+
+- sort DASDs by channel ID (part of bsc#1134927)
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 12:57:12 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -390,6 +390,8 @@ module Yast
         Builtins.tolower(Ops.get_string(d, "device", "")) == "dasd"
       end
 
+      disks.sort_by! { |disk| FormatChannel(disk.fetch("sysfs_bus_id", "0.0.0000")) }
+
       disks = Builtins.maplist(disks) do |d|
         channel = Ops.get_string(d, "sysfs_bus_id", "")
         Ops.set(d, "channel", channel)

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -114,6 +114,32 @@ describe "Yast::DASDController" do
     end
   end
 
+  describe "#GetDevices" do
+    it "returns DASDs" do
+      expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once
+        .and_return(load_data("probe_disk_dasd.yml"))
+      expect(Yast::DASDController.ProbeDisks()).to eq(nil)
+      expect(Yast::DASDController.GetDevices()).to eq(
+        0 => { "detail"        => { "cu_model" => 233, "dev_model" => 10, "lcss" => 0 },
+               "device_id"     => 276880,
+               "resource"      => { "io" => [{ "active" => false,
+                                               "length" => 1,
+                                               "mode"   => "rw",
+                                               "start"  => 352 }] },
+               "sub_device_id" => 275344,
+               "channel"       => "0.0.0150" },
+        1 => { "detail"        => { "cu_model" => 233, "dev_model" => 10, "lcss" => 0 },
+               "device_id"     => 276880,
+               "resource"      => { "io" => [{ "active" => false,
+                                               "length" => 1,
+                                               "mode"   => "rw",
+                                               "start"  => 352 }] },
+               "sub_device_id" => 275344,
+               "channel"       => "0.0.0160" }
+      )
+    end
+  end
+
   describe "#Write" do
     let(:data) do
       { "devices" => [{ "channel" => "0.0.0100", "diag" => false,

--- a/test/data/probe_disk_dasd.yml
+++ b/test/data/probe_disk_dasd.yml
@@ -32,3 +32,34 @@
   unique_key: 3VmV.ALFATSt_U8F
   vendor: IBM
   vendor_id: 286721
+- bus: CCW
+  bus_hwcfg: ccw
+  class_id: 262
+  detail:
+    cu_model: 233
+    dev_model: 10
+    lcss: 0
+  device: DASD
+  device_id: 276880
+  drivers:
+  - active: true
+    modprobe: true
+    modules:
+    - - dasd_eckd_mod
+      - ''
+  model: |-
+    IBM
+                DASD
+  prog_if: 1
+  resource:
+    io:
+    - active: false
+      length: 1
+      mode: rw
+      start: 352
+  sub_class_id: 0
+  sub_device_id: 275344
+  sysfs_bus_id: 0.0.0150
+  sysfs_id: "/devices/css0/0.0.0001/0.0.0150"
+  vendor: IBM
+  vendor_id: 286721


### PR DESCRIPTION
For https://trello.com/c/32tSXw5q/1015-5-l3-1134927-after-upgrade-to-sles-12-sp4-yast2-dasd-mgmt-does-not-show-progress-bar-progression-not-sorted. Port of #69.