### PR TITLE
Fix bsc1134927 diag

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 19 11:57:09 CEST 2019 - aschnell@suse.com
+
+- handle setting diag mode on active DASDs (part of bsc#1134927)
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Jul 16 11:27:09 CEST 2019 - aschnell@suse.com
 
 - sort DASDs by channel ID (part of bsc#1134927)

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/include/s390/dasd/dialogs.rb
+++ b/src/include/s390/dasd/dialogs.rb
@@ -285,8 +285,8 @@ module Yast
               [id, "resource", "io", 0, "active"],
               false
             )
+            DASDController.ActivateDiag(channel, value) if active
             Ops.set(DASDController.diag, channel, value)
-            DASDController.ActivateDisk(channel, value) if active
           end
           DASDController.ProbeDisks
 

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -570,6 +570,16 @@ module Yast
       nil
     end
 
+    # Activate or deactivate diag on active disk
+    # @param [String] channel string Name of the disk to operate on
+    # @param [Boolean] diag boolean Activate DIAG or not
+    def ActivateDiag(channel, diag)
+      old_diag = DASDController.diag.fetch(channel, false)
+      return if diag == old_diag
+      DeactivateDisk(channel, old_diag)
+      ActivateDisk(channel, diag)
+    end
+
     # Format disks
     # @param [Array<String>] disks_list list<string> List of disks to be formatted
     # @param [Fixnum] par integer Number of disks that can be formated in parallel

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -264,4 +264,13 @@ describe "Yast::DASDController" do
       end
     end
   end
+
+  describe "#ActivateDiag" do
+    it "deactivates and reactivates dasd" do
+      expect(Yast::DASDController).to receive(:DeactivateDisk).ordered
+      expect(Yast::DASDController).to receive(:ActivateDisk).ordered
+      expect(Yast::DASDController.ActivateDiag("0.0.3333", true)).to eq(nil)
+    end
+  end
+
 end


### PR DESCRIPTION
For https://trello.com/c/32tSXw5q/1015-5-l3-1134927-after-upgrade-to-sles-12-sp4-yast2-dasd-mgmt-does-not-show-progress-bar-progression-not-sorted. Port of PR #74.