### PR TITLE
[bsc#1158443] Properly filter zfcp

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 23 13:56:13 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Properly identify zFCP devices (bsc#1158443).
+- 4.2.4
+
+-------------------------------------------------------------------
 Wed Dec 11 14:29:18 CET 2019 - schubi@suse.de
 
 - Activating dumpconf: Ask the user to deactivate active kdump

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -371,7 +371,7 @@ module Yast
         to:   "list <map <string, any>>"
       )
       disks = Builtins.filter(disks) do |d|
-        d["bus"] == "SCSI" && (d["resource"] && d["resource"]["fc"])
+        d["driver"] == "zfcp"
       end
 
       tapes = Convert.convert(

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -371,7 +371,7 @@ module Yast
         to:   "list <map <string, any>>"
       )
       disks = Builtins.filter(disks) do |d|
-        Ops.get_string(d, "bus", "") == "SCSI"
+        d["bus"] == "SCSI" && (d["resource"] && d["resource"]["fc"])
       end
 
       tapes = Convert.convert(
@@ -415,11 +415,11 @@ module Yast
       case ret
       when 0
 
-      when 1
+      when 1 # FIXME: check error codes in https://github.com/SUSE/s390-tools/blob/master/zfcp_host_configure#L60
         Report.Error(
           Builtins.sformat(
             # error report, %1 is device identification
-            _("%1: sysfs not mounted."),
+            _("%1: no CCW was specified or sysfs is not mounted."),
             channel
           )
         )

--- a/test/data/probe_disk.yml
+++ b/test/data/probe_disk.yml
@@ -89,3 +89,43 @@
   sysfs_id: "/class/block/sdb"
   unique_key: XGop.pffu6ea6mm8
   vendor: IBM
+- bus: SCSI
+  bus_hwcfg: scsi
+  class_id: 262
+  detail:
+    channel: 0
+    fcp_lun: '0x0000000000000000'
+    host: 0
+    id: 0
+    lun: 0
+    wwpn: '0x0000000000000000'
+  dev_name: "/dev/sdc"
+  dev_name2: "/dev/sg3"
+  dev_names:
+  - "/dev/sdc"
+  - "/dev/disk/by-path/ip-10.100.12.158:3260-iscsi-iqn.2020-03.iscsi.test:for.test-lun-1"
+  dev_num:
+    major: 8
+    minor: 32
+    range: 16
+    type: b
+  device: VIRTUAL-DISK
+  driver: sd
+  driver_module: sd_mod
+  model: IET VIRTUAL-DISK
+  old_unique_key: K1ot.XFis0A0w1l6
+  resource:
+    disk_log_geo:
+    - cylinders: 20480
+      heads: 64
+      sectors: 32
+    size:
+    - unit: sectors
+      x: 41943080
+      y: 512
+  rev: '0001'
+  sub_class_id: 0
+  sysfs_bus_id: 1:0:0:1
+  sysfs_id: "/class/block/sdc"
+  unique_key: _R2u.eVSycZhnQ60
+  vendor: IET

--- a/test/zfcp_controller_test.rb
+++ b/test/zfcp_controller_test.rb
@@ -87,11 +87,13 @@ describe "Yast::ZFCPController" do
   end
 
   describe "#ProbeDisks" do
-    it "Probing disk" do
-      expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once
+    before do
+      allow(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once
         .and_return(load_data("probe_disk.yml"))
-      expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.tape")).once.and_return([])
+      allow(Yast::SCR).to receive(:Read).with(Yast.path(".probe.tape")).once.and_return([])
+    end
 
+    it "Probing disk" do
       expect(Yast::ZFCPController.ProbeDisks()).to eq(nil)
       expect(Yast::ZFCPController.devices).to eq(load_data("device_list.yml"))
     end


### PR DESCRIPTION
According to [bsc#1158443](https://bugzilla.suse.com/show_bug.cgi?id=1158443), the `ZFCPController` module is not properly filtering the zFCP devices at all and, as a consequence, iSCSI devices are considered zFCP too.

We are considering as zFCP devices those which `bus == SCSI` (see [this line](https://github.com/yast/yast-s390/blob/master/src/modules/ZFCPController.rb#L374)). The problem is that such a condition is true for iSCSI devices too (like [this one](https://github.com/yast/yast-s390/blob/d0d3414062899f338b50db00fd9eeb280bb5d770/test/data/probe_disk.yml#L92-L131)).

I found that, in the hardware information, there is a `resource` object that contains an `fc` key for zFCP devices (I guess it is related to [these lines of hwinfo](https://github.com/openSUSE/hwinfo/blob/9929bb67ef282c60370f31cd2d6cc0b7a1718a9b/src/hd/hdp.c#L800-L805)) (the following example is simplified).

```yaml
- bus: SCSI
  bus_hwcfg: scsi
  driver: zfcp
  detail:
    channel: 0
    controller_id: 0.0.fa00
    fcp_lun: '0x4001402600000000'
    host: 0
    id: 0
    lun: 0
    wwpn: '0x500507630713d3b3'
  resource:
    disk_log_geo:
    - cylinders: 20480
      heads: 64
      sectors: 32
    fc:
    - fcp_lun: 4612038025357033472
      wwpn: 5766023019819684787
    size:
    - unit: sectors
      x: 41943040
      y: 512
```

So expanding the comparison would filter out iSCSI devices:

```ruby
  d["bus"] == "SCSI" && (d["resource"] && d["resource"]["fc"]) 
```

So I have a few questions:

* Is this change safe or am I going to filter out too many devices?
* If it is safe, could I get rid of the first part of the condition (bus == SCSI)?

@wfeldt and @aschnell: please, could you have a look?