### PR TITLE
[bsc#1163149] Do not activate devices twice

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 31 13:52:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not try to activate DASD and zFCP devices that are already
+  active (bsc#1163149). Related to SLE-7396.
+- 4.2.5
+
+-------------------------------------------------------------------
 Mon Mar 23 13:56:13 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Properly identify zFCP devices (bsc#1158443).

--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -2,7 +2,7 @@
 Tue Mar 31 13:52:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not try to activate DASD and zFCP devices that are already
-  active (bsc#1163149). Related to SLE-7396.
+  active (bsc#1163149). Related to jsc#SLE-7396.
 - 4.2.5
 
 -------------------------------------------------------------------

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -485,6 +485,22 @@ module Yast
       ret["exit"]
     end
 
+    # Activates a disk if it is not active
+    #
+    # When the disk is already activated, it returns '8' if the
+    # disk is unformatted or '0' otherwise. The idea is to mimic
+    # the same API than ActivateDisk.
+    #
+    # @return [Integer] Returns an error code (8 means 'unformatted').
+    def activate_disk_if_needed(channel, diag)
+      disk = find_disks.find { |d| d["channel"] == channel }
+      if disk && active_disk?(disk)
+        log.info "Disk #{disk.inspect} is already active. Skipping the activation."
+        return disk["formatted"] ? 0 : 8
+      end
+      ActivateDisk(channel, diag)
+    end
+
     # Deactivate disk
     # @param [String] channel string Name of the disk to deactivate
     # @param [Boolean] diag boolean Activate DIAG or not
@@ -790,22 +806,6 @@ module Yast
       else
         Yast2::Popup.show(message, headline: headline, details: details)
       end
-    end
-
-    # Activates a disk if its not activated
-    #
-    # When the disk is already activated, it returns '8' if the
-    # disk is unformatted or '0' otherwise. The idea is to mimic
-    # the same API than ActivateDisk.
-    #
-    # @return [Integer] Returns an error code (8 means 'unformatted').
-    def activate_disk_if_needed(channel, diag)
-      disk = find_disks.find { |d| d["channel"] == channel }
-      if disk && active_disk?(disk)
-        log.info "Disk #{disk.inspect} is already active. Skipping the activation."
-        return disk["formatted"] ? 0 : 8
-      end
-      ActivateDisk(channel, diag)
     end
 
     # Determines whether the disk is activated or not

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -816,8 +816,8 @@ module Yast
     # @param disk [Hash]
     # @return [Boolean]
     def active_disk?(disk)
-      io = disk.fetch("resource", {}).fetch("io", []).first
-      !!(io && io["active"])
+      io = disk.fetch("resource", {}).fetch("io", [])
+      io.any? { |i| i["active"] }
     end
 
     # Returns the DASD disks

--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -801,8 +801,11 @@ module Yast
     # @return [Boolean] Returns an error code (8 means 'unformatted').
     def activate_disk_if_needed(channel, diag)
       disk = find_disks.find { |d| d["channel"] == channel }
-      return ActivateDisk(channel, diag) unless disk && active_disk?(disk)
-      disk["formatted"] ? 0 : 8
+      if disk && active_disk?(disk)
+        log.info "Disk #{channel} is already active. Skipping the activation."
+        return disk["formatted"] ? 0 : 8
+      end
+      ActivateDisk(channel, diag) unless disk && active_disk?(disk)
     end
 
     # Determines whether the disk is activated or not

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -366,7 +366,7 @@ module Yast
       UI.OpenDialog(Label(_("Reading Configured ZFCP Devices")))
 
       index = -1
-      @devices = Builtins.listmap(find_disks(true)) do |d|
+      @devices = Builtins.listmap(find_disks(force_probing: true)) do |d|
         index = Ops.add(index, 1)
         { index => d }
       end
@@ -581,7 +581,7 @@ module Yast
     def ActivateDisk(channel, wwpn, lun)
       disk = find_disk(channel, wwpn, lun)
       if disk
-        log.info "Disk #{channel}:#{wwpn}:#{lun} is already active. Skipping the activation."
+        log.info "Disk #{disk.inspect} is already active. Skipping the activation."
       else
         activate_controller(channel)
       end
@@ -724,7 +724,7 @@ module Yast
     #
     # @param channel [String] Channel
     def register_as_activated(channel)
-      @activated_controllers << channel
+      activated_controllers.push(channel)
     end
 
     # Determines whether a controller is activated or not
@@ -741,7 +741,7 @@ module Yast
     #
     # @param force_probing [Boolean] Ignore the cached values and probes again.
     # @return [Array<Hash>] Found zFCP disks
-    def find_disks(force_probing = false)
+    def find_disks(force_probing: false)
       return @disks if @disks && !force_probing
       disks = Convert.convert(
         SCR.Read(path(".probe.disk")),

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -581,7 +581,7 @@ module Yast
     def ActivateDisk(channel, wwpn, lun)
       disk = find_disk(channel, wwpn, lun)
       if disk
-        log.info "Disk #{channel}:#{wwpn}:#{lun} is already active. Skipping activation."
+        log.info "Disk #{channel}:#{wwpn}:#{lun} is already active. Skipping the activation."
       else
         activate_controller(channel)
       end
@@ -716,6 +716,7 @@ module Yast
         io = ctrl.fetch("resource", {}).fetch("io", []).first
         io && io["active"]
       end
+      log.info "Already activated controllers: #{ctrls}"
       @activated_controllers = ctrls.map { |c| c["sysfs_bus_id"] }
     end
 

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -713,8 +713,8 @@ module Yast
     def activated_controllers
       return @activated_controllers if @activated_controllers
       ctrls = GetControllers().select do |ctrl|
-        io = ctrl.fetch("resource", {}).fetch("io", []).first
-        io && io["active"]
+        io = ctrl.fetch("resource", {}).fetch("io", [])
+        io.any? { |i| i["active"] }
       end
       log.info "Already activated controllers: #{ctrls}"
       @activated_controllers = ctrls.map { |c| c["sysfs_bus_id"] }

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -724,7 +724,7 @@ module Yast
     #
     # @param channel [String] Channel
     def register_as_activated(channel)
-      activated_controllers.push(channel)
+      activated_controllers << channel
     end
 
     # Determines whether a controller is activated or not

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -4,7 +4,7 @@ require_relative "./test_helper"
 
 Yast.import "DASDController"
 
-describe "Yast::DASDController" do
+describe Yast::DASDController do
   subject { Yast::DASDController }
 
   describe "#DeactivateDisk" do
@@ -110,7 +110,7 @@ describe "Yast::DASDController" do
     it "returns true if .probe.disk contains DASDs" do
       expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once
         .and_return(load_data("probe_disk_dasd.yml"))
-      expect(Yast::DASDController.IsAvailable()).to eq(true)
+      expect(subject.IsAvailable()).to eq(true)
     end
   end
 
@@ -118,8 +118,8 @@ describe "Yast::DASDController" do
     it "returns DASDs" do
       expect(Yast::SCR).to receive(:Read).with(Yast.path(".probe.disk")).once
         .and_return(load_data("probe_disk_dasd.yml"))
-      expect(Yast::DASDController.ProbeDisks()).to eq(nil)
-      expect(Yast::DASDController.GetDevices()).to eq(
+      expect(subject.ProbeDisks()).to eq(nil)
+      expect(subject.GetDevices()).to eq(
         0 => { "detail"        => { "cu_model" => 233, "dev_model" => 10, "lcss" => 0 },
                "device_id"     => 276880,
                "resource"      => { "io" => [{ "active" => false,
@@ -158,19 +158,19 @@ describe "Yast::DASDController" do
       allow(Yast::Mode).to receive(:autoinst).and_return(true)
       # speed up the test a bit
       allow(Yast::Builtins).to receive(:sleep)
-      allow(Yast::DASDController).to receive(:ActivateDisk).and_return(0)
-      allow(Yast::DASDController).to receive(:GetDeviceName).and_return("/dev/dasda")
+      allow(subject).to receive(:ActivateDisk).and_return(0)
+      allow(subject).to receive(:GetDeviceName).and_return("/dev/dasda")
     end
 
     context "during autoinstallation" do
       before do
-        Yast::DASDController.Import(data)
+        subject.Import(data)
       end
 
       it "activates the disk" do
-        allow(Yast::DASDController).to receive(:FormatDisks)
-        expect(Yast::DASDController).to receive(:ActivateDisk).with("0.0.0100", false)
-        Yast::DASDController.Write
+        allow(subject).to receive(:FormatDisks)
+        expect(subject).to receive(:ActivateDisk).with("0.0.0100", false)
+        subject.Write
       end
 
       context "when 'format' is sets to true" do
@@ -180,7 +180,7 @@ describe "Yast::DASDController" do
           # bnc 928388
           expect(Yast::SCR).to receive(:Execute).with(path(".process.start_shell"),
             "/sbin/dasdfmt -Y -P 1 -b 4096 -y -r 10 -m 10 -f '/dev/dasda'")
-          expect(Yast::DASDController.Write).to eq(true)
+          expect(subject.Write).to eq(true)
         end
       end
 
@@ -188,8 +188,8 @@ describe "Yast::DASDController" do
         let(:format) { false }
 
         it "does not format the disk" do
-          expect(Yast::DASDController).to_not receive(:FormatDisks)
-          Yast::DASDController.Write
+          expect(subject).to_not receive(:FormatDisks)
+          subject.Write
         end
       end
 
@@ -199,7 +199,7 @@ describe "Yast::DASDController" do
         let(:format) { false }
 
         before do
-          allow(Yast::DASDController).to receive(:ActivateDisk).with("0.0.0100", false)
+          allow(subject).to receive(:ActivateDisk).with("0.0.0100", false)
             .and_return(NOT_FORMATTED_CODE)
         end
 
@@ -207,8 +207,8 @@ describe "Yast::DASDController" do
           let(:format_unformatted) { true }
 
           it "formats the device" do
-            expect(Yast::DASDController).to receive(:FormatDisks).with(["/dev/dasda"], anything)
-            Yast::DASDController.Write
+            expect(subject).to receive(:FormatDisks).with(["/dev/dasda"], anything)
+            subject.Write
           end
         end
 
@@ -216,8 +216,8 @@ describe "Yast::DASDController" do
           let(:format_unformatted) { false }
 
           it "does not format the device" do
-            expect(Yast::DASDController).to_not receive(:FormatDisks)
-            Yast::DASDController.Write
+            expect(subject).to_not receive(:FormatDisks)
+            subject.Write
           end
         end
 
@@ -226,14 +226,14 @@ describe "Yast::DASDController" do
           let(:format_unformatted) { false }
 
           it "formats the device" do
-            expect(Yast::DASDController).to receive(:FormatDisks).with(["/dev/dasda"], anything)
-            Yast::DASDController.Write
+            expect(subject).to receive(:FormatDisks).with(["/dev/dasda"], anything)
+            subject.Write
           end
 
           it "reactivates the disk" do
-            expect(Yast::DASDController).to receive(:FormatDisks)
-            expect(Yast::DASDController).to receive(:ActivateDisk).twice
-            Yast::DASDController.Write
+            expect(subject).to receive(:FormatDisks)
+            expect(subject).to receive(:ActivateDisk).twice
+            subject.Write
           end
         end
       end
@@ -246,8 +246,8 @@ describe "Yast::DASDController" do
         expect(Yast::SCR).to_not receive(:Execute).with(path(".process.start_shell"),
           /dasdfmt.*\/dev\/dasda/)
 
-        expect(Yast::DASDController.Import(data)).to eq(true)
-        expect(Yast::DASDController.Write).to eq(true)
+        expect(subject.Import(data)).to eq(true)
+        expect(subject.Write).to eq(true)
       end
     end
   end
@@ -357,9 +357,9 @@ describe "Yast::DASDController" do
 
   describe "#ActivateDiag" do
     it "deactivates and reactivates dasd" do
-      expect(Yast::DASDController).to receive(:DeactivateDisk).ordered
-      expect(Yast::DASDController).to receive(:ActivateDisk).ordered
-      expect(Yast::DASDController.ActivateDiag("0.0.3333", true)).to eq(nil)
+      expect(subject).to receive(:DeactivateDisk).ordered
+      expect(subject).to receive(:ActivateDisk).ordered
+      expect(subject.ActivateDiag("0.0.3333", true)).to eq(nil)
     end
   end
 

--- a/test/dasd_controller_test.rb
+++ b/test/dasd_controller_test.rb
@@ -47,6 +47,58 @@ describe Yast::DASDController do
     end
   end
 
+  describe "#activate_disk_if_needed" do
+    let(:channel) { "0.0.0150" }
+    let(:formatted) { true }
+    let(:active) { true }
+
+    let(:disk) do
+      {
+        "dev_name"  => "/dev/dasda",
+        "formatted" => formatted,
+        "channel"   => channel,
+        "resource"  => {
+          "io" => [{ "active" => active }]
+        }
+      }
+    end
+
+    before do
+      allow(subject).to receive(:find_disks).and_return([disk])
+    end
+
+    context "when the disk is already active" do
+      it "does not activate the disk" do
+        expect(subject).to_not receive(:ActivateDisk)
+        subject.activate_disk_if_needed(channel, false)
+      end
+
+      context "and it is not formatted" do
+        let(:formatted) { false }
+
+        it "returns 8" do
+          expect(subject.activate_disk_if_needed(channel, false)).to eq(8)
+        end
+      end
+
+      context "and it is formatted" do
+        it "returns 0" do
+          expect(subject.activate_disk_if_needed(channel, false)).to eq(0)
+        end
+      end
+    end
+
+    context "when the disk is not active" do
+      let(:active) { false }
+
+      it "activates the disk" do
+        expect(subject).to receive(:ActivateDisk).with(channel, false)
+          .and_return(0)
+        expect(subject.activate_disk_if_needed(channel, false)).to eq(0)
+      end
+    end
+  end
+
   describe "#DeactivateDisk" do
     let(:auto) { false }
     let(:channel) { "0.0.0160" }

--- a/test/data/probe_storage.yml
+++ b/test/data/probe_storage.yml
@@ -108,7 +108,7 @@
   old_unique_key: _AAN.6czr7zOIMz1
   resource:
     io:
-    - active: true
+    - active: false
       length: 3
       mode: rw
       start: 64512

--- a/test/zfcp_controller_test.rb
+++ b/test/zfcp_controller_test.rb
@@ -4,7 +4,7 @@ require_relative "./test_helper"
 
 Yast.import "ZFCPController"
 
-describe "Yast::ZFCPController" do
+describe Yast::ZFCPController do
   before do
     Yast::ZFCPController.main
   end
@@ -20,18 +20,18 @@ describe "Yast::ZFCPController" do
     end
 
     it "activates the controller and the given disk" do
-      expect(Yast::ZFCPController).to receive(:activate_controller).with("0.0.fa00")
+      expect(subject).to receive(:activate_controller).with("0.0.fa00")
       expect(Yast::SCR).to receive(:Execute)
         .with(anything, /\/sbin\/zfcp_disk_configure '0.0.fa00' '0x500\d+' '0x401\d+' 1/)
         .and_return(0)
-      Yast::ZFCPController.ActivateDisk("0.0.fa00", "0x5000000000000000", "0x4010400000000000")
+      subject.ActivateDisk("0.0.fa00", "0x5000000000000000", "0x4010400000000000")
     end
 
     context "when the disk is already active" do
       it "does not try to active the given disk" do
-        allow(Yast::ZFCPController).to receive(:activate_controller).with("0.0.fa00")
+        allow(subject).to receive(:activate_controller).with("0.0.fa00")
         expect(Yast::SCR).to_not receive(:Execute)
-        Yast::ZFCPController.ActivateDisk("0.0.fa00", "0x500507630500873a", "0x4010400000000000")
+        subject.ActivateDisk("0.0.fa00", "0x500507630500873a", "0x4010400000000000")
       end
     end
   end
@@ -55,15 +55,15 @@ describe "Yast::ZFCPController" do
     it "activates the given controller" do
       expect(Yast::SCR).to receive(:Execute)
         .with(anything, /\/sbin\/zfcp_host_configure '0.0.fc00' 1/).and_return(0)
-      expect(Yast::ZFCPController).to_not receive(:ReportControllerActivationError)
-      Yast::ZFCPController.activate_controller(channel)
+      expect(subject).to_not receive(:ReportControllerActivationError)
+      subject.activate_controller(channel)
     end
 
     it "does not activate a controller twice" do
       expect(Yast::SCR).to receive(:Execute)
         .with(anything, /\/sbin\/zfcp_host_configure '0.0.fc00' 1/).once.and_return(0)
-      Yast::ZFCPController.activate_controller(channel)
-      Yast::ZFCPController.activate_controller(channel)
+      subject.activate_controller(channel)
+      subject.activate_controller(channel)
     end
 
     context "when the activation fails" do
@@ -73,9 +73,9 @@ describe "Yast::ZFCPController" do
       end
 
       it "reports the error" do
-        expect(Yast::ZFCPController).to receive(:ReportControllerActivationError)
+        expect(subject).to receive(:ReportControllerActivationError)
           .with("0.0.fc00", 1)
-        Yast::ZFCPController.activate_controller(channel)
+        subject.activate_controller(channel)
       end
     end
 
@@ -89,7 +89,7 @@ describe "Yast::ZFCPController" do
 
       it "does not activate the controller" do
         expect(Yast::SCR).to_not receive(:Execute).with(anything, /\/sbin\/zfcp_host_configure/)
-        Yast::ZFCPController.activate_controller(channel)
+        subject.activate_controller(channel)
       end
     end
   end
@@ -107,7 +107,7 @@ describe "Yast::ZFCPController" do
       )
       expect(Yast::SCR).to receive(:Execute).with(anything, /\/sbin\/cio_ignore -r f800/).and_return(0)
 
-      ctrls = Yast::ZFCPController.GetControllers
+      ctrls = subject.GetControllers
       expect(ctrls).to contain_exactly(
         hash_including("sysfs_bus_id" => "0.0.f800"),
         hash_including("sysfs_bus_id" => "0.0.f900"),
@@ -134,7 +134,7 @@ describe "Yast::ZFCPController" do
         let(:is_zkvm) { false }
         it "reports a warning" do
           expect(Yast::Report).to receive(:Warning).with(/Cannot evaluate ZFCP controllers/)
-          Yast::ZFCPController.GetControllers
+          subject.GetControllers
         end
       end
 
@@ -142,7 +142,7 @@ describe "Yast::ZFCPController" do
         let(:is_zkvm) { true }
         it "does not report a warning" do
           expect(Yast::Report).to_not receive(:Warning).with(/Cannot evaluate ZFCP controllers/)
-          Yast::ZFCPController.GetControllers
+          subject.GetControllers
         end
       end
     end
@@ -155,8 +155,8 @@ describe "Yast::ZFCPController" do
                                     { "controller_id" => "0.0.f800" },
                                     { "controller_id" => "0.0.f900" }] }
 
-      expect(Yast::ZFCPController.Import(import_data)).to eq(true)
-      expect(Yast::ZFCPController.GetDeviceIndex("0.0.f800", "", "")).to eq(2)
+      expect(subject.Import(import_data)).to eq(true)
+      expect(subject.GetDeviceIndex("0.0.f800", "", "")).to eq(2)
     end
   end
 
@@ -168,8 +168,8 @@ describe "Yast::ZFCPController" do
     end
 
     it "Probing disk" do
-      expect(Yast::ZFCPController.ProbeDisks()).to eq(nil)
-      expect(Yast::ZFCPController.devices).to eq(load_data("device_list.yml"))
+      expect(subject.ProbeDisks()).to eq(nil)
+      expect(subject.devices).to eq(load_data("device_list.yml"))
     end
   end
 
@@ -181,10 +181,10 @@ describe "Yast::ZFCPController" do
                                     { "controller_id" => "0.0.f800" },
                                     { "controller_id" => "0.0.f900" }] }
 
-      expect(Yast::ZFCPController.Import(import_data)).to eq(true)
-      Yast::ZFCPController.filter_max = Yast::ZFCPController.FormatChannel("0.0.FA00")
-      Yast::ZFCPController.filter_min = Yast::ZFCPController.FormatChannel("0.0.f900")
-      expect(Yast::ZFCPController.GetFilteredDevices()).to eq(
+      expect(subject.Import(import_data)).to eq(true)
+      subject.filter_max = subject.FormatChannel("0.0.FA00")
+      subject.filter_min = subject.FormatChannel("0.0.f900")
+      expect(subject.GetFilteredDevices()).to eq(
         0 => { "detail"=>{ "controller_id" => "0.0.fa00", "wwpn" => "", "fcp_lun" => "" } },
         4 => { "detail"=>{ "controller_id" => "0.0.f900", "wwpn" => "", "fcp_lun" => "" } }
       )


### PR DESCRIPTION
This PR implements support for kernel activated devices in s390 systems. Until now, AutoYaST took care of activating `zfcp` and `dasd` devices. From now on, those devices can be already pre-configured, so AutoYaST should check if they are already activated.

This PR skips the activation for:

* zFCP controllers
* zFCP disks
* DASD disks

For the time being, I have decided to simply write a message in the log (the device is activated, so what?). But we can decide to display some kind of message if preferred.

Trello: https://trello.com/c/MNlAfnwx/

## A simpler approach?

After finishing the PR, I realized that in SP1 (not sure about SP2) the configuration scripts for zFCP devices will not complain about a device being activated twice. Actually, the original bug is caused because we are trying to change the `diag` configuration value of an already activated one.

So if this code looks too much, we could simply keep the behavior for DASD devices and ignore zFCP.

## TODO

- [x] Handle DASD disks
- [x] Handle zFCP controllers
- [x] Handle zFCP LUNs
- [x] Display a message (or register it on the log)