### PR TITLE
AutoYaST: Added supplements: autoyast(xpram,zfcp,dasd) into the spec …

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Aug 10 14:59:52 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Added supplements: autoyast(xpram,zfcp,dasd) into the
+  spec file in order to install this packages if the section has
+  been defined in the AY configuration file (bsc#1146494).
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 14:50:34 UTC 2020 - josef Reidinger <jreidinger@localhost>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -40,6 +40,7 @@ Requires:       yast2-ruby-bindings >= 3.1.7
 Requires:       s390-tools
 
 Supplements:    yast2-storage-ng
+supplements:    autoyast(xpram,zfcp,dasd)
 
 ExclusiveArch:  s390 s390x
 

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -40,7 +40,7 @@ Requires:       yast2-ruby-bindings >= 3.1.7
 Requires:       s390-tools
 
 Supplements:    yast2-storage-ng
-supplements:    autoyast(xpram,zfcp,dasd)
+Supplements:    autoyast(xpram,zfcp,dasd)
 
 ExclusiveArch:  s390 s390x
 


### PR DESCRIPTION
…file in order to install this packages if the section has been defined in the AY configuration file (bsc#1146494).