### PR TITLE
do not activate DASD devices after formatting (bsc#1187012)

### DIFF
--- a/src/include/s390/dasd/dialogs.rb
+++ b/src/include/s390/dasd/dialogs.rb
@@ -368,11 +368,6 @@ module Yast
           end
           DASDController.FormatDisks(devices, num_parallel)
 
-          channels.each do |channel|
-            diag = DASDController.diag.fetch(channel, false)
-            DASDController.ActivateDisk(channel, diag)
-          end
-
           DASDController.ProbeDisks
 
           return true


### PR DESCRIPTION
Because they are obviously already active (they have just been formatted).