### PR TITLE
do not activate DASD devices after formatting (bsc#1187012)

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 24 16:07:05 UTC 2021 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not activate DASD devices after formatting (bsc#1187012)
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/include/s390/dasd/dialogs.rb
+++ b/src/include/s390/dasd/dialogs.rb
@@ -368,10 +368,8 @@ module Yast
           end
           DASDController.FormatDisks(devices, num_parallel)
 
-          channels.each do |channel|
-            diag = DASDController.diag.fetch(channel, false)
-            DASDController.ActivateDisk(channel, diag)
-          end
+          # We used to explicitly activate the DASD devices here, don't do
+          # it - see bsc#1187012.
 
           DASDController.ProbeDisks
 


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-s390/pull/89 to master.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1187012
- https://trello.com/c/N39SyWPy

After formatting DASD devices, `yast dasd` shows `Error: Cannot set use_diag='0' while online='1'`.

The cause is that `dasd_configure` has a bit of a problem handling the `use_diag` setting. See [this analysis](https://bugzilla.suse.com/show_bug.cgi?id=1187012#c45) for details.

## Solution

The bottom line is not to try to activate an already active DASD with `dasd_configure`. And since they have just been formatted, they are obviously already active. So simply skip this step.