### PR TITLE
Don't call 'mkinitrd' in the inst-sys

### DIFF
--- a/src/modules/DASDController.rb
+++ b/src/modules/DASDController.rb
@@ -107,7 +107,7 @@ module Yast
     def Write
       Y2S390::DasdsWriter.new(@devices).write if !Mode.normal
 
-      if !Mode.installation && @disk_configured
+      if Mode.normal && @disk_configured
         Y2S390::Dialogs::Mkinitrd.new.run
         @disk_configured = false
       end


### PR DESCRIPTION
## Target Branch

**SLE-15-SP4**

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1197632


## Trello

https://trello.com/c/hElIyiJA


## Problem

During AutoYaST upgrade (or also during normal upgrade) on s/390 just after activating / configuring a DASD, the installation threw an error pop-up

  _No such file or directory - /sbin/mkinitrd_


## Cause

There is no `mkinitrd` command in the inst-sys. It also shouldn't even be there; the installation runs `dracut` during the execution phase of the installation when the bootloader is installed. `mkinitrd` should not be called at all during the installation or upgrade (with or without AutoYaST).

## Fix

Change the check from

```
if !Mode.installation && @disk_configured
```

to

```
if Mode.normal && @disk_configured
```

Notice that `Mode.installation` also includes _auto_installation. `Mode.normal` means "in the installed system", i.e. when a YaST module is called standalone from the YaST control center.


### Did that ever work?

No, not during system upgrade / autoupgrade.


### So why did that go unnoticed for so long?

During the last changes, @teclator refactored that part also to move the whole process of calling the `mkinitrd` command and opening and closing a pop-up out to a separate Ruby class; and used the state-of-the art `Yast.Execute` instead of the old `SCR.Execute(path(".target.bash", ...)`.

But where `SCR.Execute` just wrote an error to the y2log when the external program could not be executed, so the problem usually remained unseen, the new `Yast.Execute` does not just hide the error, it displays it to the user in an error pop-up.


## Related PR

TBD: PR URL for master
