### PR TITLE
Fixed git failure in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
     - name: Adapt Spec
       run: sed -i "/^ExclusiveArch:/d" package/*.spec
 
-    - name: Mark Spec
-      run: git add package/*.spec
-
     - name: Package Build
       run: yast-ci-ruby -o package
+      env:
+        # ignore the spec file modification done above
+        CHECK_MODIFIED: 0
 
   # downloading the Docker image takes some time so bundling several fast
   # checks into one job avoids that overhead


### PR DESCRIPTION
- Similar to https://github.com/yast/ci-ruby-container/pull/19
- Originally I wanted to use the same `chown` workaround here as well, but then I realized we can just set `CHECK_MODIFIED=0` to disable the check for modified GIT files and avoid calling `git` completely.
- See https://github.com/openSUSE/packaging_rake_tasks#oscbuild
