### PR TITLE
Prevent Crash if Closing the DASD Context Menu without Action [SLE-15-SP5]

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May 10 13:35:34 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent crash when the user closes the DASD context menu
+  without action (bsc#1211213)
+- Graceful handling of missing actions in the DASD context menu:
+  just log an error, don't crash
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/include/s390/dasd/dialogs.rb
+++ b/src/include/s390/dasd/dialogs.rb
@@ -142,7 +142,14 @@ module Yast
     # @param action [Y2S390::DasdAction] the action to perform
     # @param selected [Y2S390::DasdsCollection] the collection of DASD devices to work with
     def run(action, selected)
-      Object.const_get(action_class_for(action)).run(selected)
+      return false if action == :cancel # Ignore closing the context menu (bsc#1211213)
+
+      begin
+        Object.const_get(action_class_for(action)).run(selected)
+      rescue NameError => e
+        log.error("No action for #{action}: #{e}")
+        return false
+      end
     end
 
     def PerformAction(action)


### PR DESCRIPTION
## Target Branch / Release

This is the merge to _master_ / _Factory_ / _TW_ of #103.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1211213


## Problem

Closing the context menu of the DASD list without executing any of its actions (e.g. by clicking outside the context menu or with the [Esc] key) caused a hard crash:

```
uninitialized constant Y2S390::DasdActions::Cancel
```


## Cause

The `UI.YContextMenu` used here sends a `CancelEvent` (ID `:cancel`) when the user closes the menu without action. The yast-s390 code simply converted the received ID into a Ruby symbol for an action class to be executed and tried to run that class.


## Fix

- Now explicitly catching action `:cancel` and ignoring it.

- Now generally checking if there actually is an action class for that symbol and logging an error instead of just crashing:

```
2023-05-10 15:20:39 <3> balrog(19572) [Ruby] dasd/dialogs.rb(rescue in run):150 No action for cancel: uninitialized constant Y2S390::DasdActions::Cancel
```

## Test

Manual test with mocked data as described [here](https://github.com/yast/yast-s390#development):

- Selecting a DASD from the list and opening the context menu
- Clicking outside the context menu to close it
- Opening it again and using the `Esc` key to close it

No complaint should appear in the log for this `:cancel` action.

- Commented out the new `return false if action == :cancel ` line and trying again: Now there should be an error in the y2log `No action for cancel: uninitialized constant Y2S390::DasdActions::Cancel`.


## Other affected Places in YaST

This one place in the yast2-s390 DASD handling is really the only place (that we found) all over YaST where we use that YContextMenu, so the problem should not appear anywhere else.


## Fix in the UI

The behavior of that YContextMenu is very weird. Closing a menu without any action should _never_ send any event (i.e. make `UI.UserInput()` return any value); it should just silently close the menu, and that should be it.

But that behavior has been unchanged since 15 years ago, so there is the slight chance that other Open Source software which uses libyui may be affected. But sending a `CancelEvent` in that case is almost certainly always unwelcome, so fixing it also in our own upstream libyui-qt should only be an improvement.

## Related PR

- Original for SLE-15-SP5: #103 