### PR TITLE
Provide allow_lun_scan info

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 14 14:38:18 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Add info about allow_lun_scan option (related to
+  gh#openSUSE/agama#626).
+- 4.6.3
+
+-------------------------------------------------------------------
 Mon Jun  5 10:09:02 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Expose zFCP core functionallity (related to

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2s390/zfcp.rb
+++ b/src/lib/y2s390/zfcp.rb
@@ -26,6 +26,9 @@ module Y2S390
     include Yast
     include Yast::Logger
 
+    ALLOW_LUN_SCAN_FILE = "/sys/module/zfcp/parameters/allow_lun_scan".freeze
+    private_constant :ALLOW_LUN_SCAN_FILE
+
     # Detected controllers
     #
     # @return [Array<Hash>] keys for each hash:
@@ -41,6 +44,20 @@ module Y2S390
     def initialize
       @controllers = []
       @disks = []
+    end
+
+    # Whether the allow_lun_scan option is active
+    #
+    # Having allow_lun_scan active has some implications:
+    #   * All LUNs are automatically activated when the controller is activated.
+    #   * LUNs cannot be deactivated.
+    #
+    # @return [Boolean]
+    def allow_lun_scan?
+      return false unless File.exist?(ALLOW_LUN_SCAN_FILE)
+
+      allow = Yast::SCR.Read(path(".target.string"), ALLOW_LUN_SCAN_FILE).chomp
+      allow == "Y"
     end
 
     # Probes the zFCP controllers

--- a/src/lib/y2s390/zfcp.rb
+++ b/src/lib/y2s390/zfcp.rb
@@ -22,6 +22,12 @@ require "yaml"
 
 module Y2S390
   # Manager for zFCP devices
+  #
+  # About allow_lun_scan option:
+  #   * It is enabled by default since SLE 12.
+  #   * It can be disabled by means of a kernel parameter (zfcp.allow_lun_scan=0).
+  #   * Configuring it once the system boots is discouraged, see
+  #     https://bugzilla.suse.com/show_bug.cgi?id=1210597#c20
   class ZFCP
     include Yast
     include Yast::Logger

--- a/src/lib/y2s390/zfcp.rb
+++ b/src/lib/y2s390/zfcp.rb
@@ -107,6 +107,20 @@ module Y2S390
       io.any? { |i| i["active"] }
     end
 
+    # Whether the controller is performing auto LUN scan
+    #
+    # For that, allow_lun_scan must be active and the controller must be running in NPIV mode.
+    #
+    # @param channel [String] E.g., "0.0.fa00"
+    # @return [Boolean]
+    def lun_scan_controller?(channel)
+      file = "/sys/bus/ccw/drivers/zfcp/#{channel}/host0/fc_host/host0/port_type"
+      return false unless allow_lun_scan? && File.exist?(file)
+
+      mode = Yast::SCR.Read(path(".target.string"), file).chomp
+      mode == "NPIV VPORT"
+    end
+
     # Runs the command for activating a zFCP disk
     #
     # @param channel [String] E.g., "0.0.fa00"

--- a/test/y2s390/zfcp_test.rb
+++ b/test/y2s390/zfcp_test.rb
@@ -23,6 +23,34 @@ require_relative "../test_helper"
 require "y2s390/zfcp"
 
 describe Y2S390::ZFCP do
+  describe "#allow_lun_scan?" do
+    before do
+      allow(File).to receive(:exist?)
+        .with("/sys/module/zfcp/parameters/allow_lun_scan")
+        .and_return(true)
+
+      allow(Yast::SCR).to receive(:Read)
+        .with(anything, "/sys/module/zfcp/parameters/allow_lun_scan")
+        .and_return(allow_lun_scan)
+    end
+
+    context "if allow_lun_scan is active" do
+      let(:allow_lun_scan) { "Y" }
+
+      it "returns true" do
+        expect(subject.allow_lun_scan?).to eq(true)
+      end
+    end
+
+    context "if allow_lun_scan is not active" do
+      let(:allow_lun_scan) { "N" }
+
+      it "returns false" do
+        expect(subject.allow_lun_scan?).to eq(false)
+      end
+    end
+  end
+
   describe "#probe_controllers" do
     before do
       allow(Yast::SCR).to receive(:Read).with(Yast.path(".probe.storage"))


### PR DESCRIPTION
## Problem

zFCP behavior depends on the *allow_lun_scan* option and the controller running mode. If *allow_lun_scan* is active and the controller is running in NPIV mode, then all LUNs are automatically activated as side effect of activating its controller. Moreover, automatically activated LUNs cannot be manually deactivated.

This change in behavior implies that clients need to know whether a controller is auto scanning LUNs in order to provide the proper options for each case.   

## Solution

Extend `Y2S390::ZFCP` class: 
  * `#allow_lun_scan?`: status of *allow_lun_scan* option.
  * `#lun_scan_controller?(channel)`: whether the controller is automatically scanning LUNs.

## Testing

* Added unit tests
