### PR TITLE
Fix zFCP runnning mode detection

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul  4 09:01:24 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Fix detection of the zFCP controller running mode to check
+  whether the controller is doing auto LUN scan (related to
+  gh#openSUSE/agama#634).
+- 4.6.4
+
+-------------------------------------------------------------------
 Wed Jun 14 14:38:18 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add info about allow_lun_scan option (related to

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2s390/zfcp.rb
+++ b/src/lib/y2s390/zfcp.rb
@@ -120,11 +120,11 @@ module Y2S390
     # @param channel [String] E.g., "0.0.fa00"
     # @return [Boolean]
     def lun_scan_controller?(channel)
-      file = "/sys/bus/ccw/drivers/zfcp/#{channel}/host0/fc_host/host0/port_type"
-      return false unless allow_lun_scan? && File.exist?(file)
+      files = Dir["/sys/bus/ccw/drivers/zfcp/#{channel}/host*/fc_host/host*/port_type"]
+      return false unless allow_lun_scan? && files.any?
 
-      mode = Yast::SCR.Read(path(".target.string"), file).chomp
-      mode == "NPIV VPORT"
+      port_types = files.map { |f| Yast::SCR.Read(path(".target.string"), f).chomp }
+      port_types.any? { |t| t == "NPIV VPORT" }
     end
 
     # Runs the command for activating a zFCP disk

--- a/test/y2s390/zfcp_test.rb
+++ b/test/y2s390/zfcp_test.rb
@@ -180,18 +180,14 @@ describe Y2S390::ZFCP do
         .with(anything, "/sys/module/zfcp/parameters/allow_lun_scan")
         .and_return(allow_lun_scan)
 
-      allow(File).to receive(:exist?)
-        .with("/sys/bus/ccw/drivers/zfcp/0.0.fa00/host0/fc_host/host0/port_type")
-        .and_return(controller_active)
-
-      allow(Yast::SCR).to receive(:Read)
-        .with(anything, "/sys/bus/ccw/drivers/zfcp/0.0.fa00/host0/fc_host/host0/port_type")
-        .and_return(controller_mode)
+      allow(Dir).to receive(:[])
+        .with("/sys/bus/ccw/drivers/zfcp/0.0.fa00/host*/fc_host/host*/port_type")
+        .and_return(port_type_files)
     end
 
     let(:allow_lun_scan) { nil }
 
-    let(:controller_active) { nil }
+    let(:port_type_files) { [] }
 
     let(:controller_mode) { nil }
 
@@ -206,7 +202,7 @@ describe Y2S390::ZFCP do
     context "if allow_lun_scan is active and the controller is not active" do
       let(:allow_lun_scan) { true }
 
-      let(:controller_active) { false }
+      let(:port_type_files) { [] }
 
       it "returns false" do
         expect(subject.lun_scan_controller?("0.0.fa00")).to eq(false)
@@ -216,7 +212,13 @@ describe Y2S390::ZFCP do
     context "if allow_lun_scan is active and the controller is active" do
       let(:allow_lun_scan) { true }
 
-      let(:controller_active) { true }
+      let(:port_type_files) { ["/sys/bus/ccw/drivers/zfcp/0.0.fa00/host0/fc_host/host0/port_type"] }
+
+      before do
+        allow(Yast::SCR).to receive(:Read)
+          .with(anything, "/sys/bus/ccw/drivers/zfcp/0.0.fa00/host0/fc_host/host0/port_type")
+          .and_return(controller_mode)
+      end
 
       context "and the controller is not running in NPIV mode" do
         let(:controller_mode) { "" }


### PR DESCRIPTION
## Problem

The detection of the controller running mode was always checking the *host0* file (*"/sys/bus/ccw/drivers/zfcp/0.0.fa00/host0/fc_host/host0/port_type"*) but it can be any host number.

Because of that, for some controllers it could be wrongly considered that auto LUN scan is not used.  

Related to https://github.com/openSUSE/agama/pull/634.

## Solution

Detect the controller running mode by checking all the host numbers.

## Testing

-  Updated unit test
- Tested manually

