### PR TITLE
onpanic: add support for multipathed zfcp-attached SCSI disks

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,7 +1,15 @@
 -------------------------------------------------------------------
+Tue Dec 12 14:35:37 UTC 2023 - Steffen Maier <maier@linux.ibm.com>
+
+- onpanic: add support for multipathed zfcp-attached SCSI disks
+  (bsc#1020336, also related to bsc#1216257).
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.0
 
 -------------------------------------------------------------------
 Wed May 10 13:35:34 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -3,13 +3,12 @@ Tue Dec 12 14:35:37 UTC 2023 - Steffen Maier <maier@linux.ibm.com>
 
 - onpanic: add support for multipathed zfcp-attached SCSI disks
   (bsc#1020336, also related to bsc#1216257).
-- 4.6.1
+- 4.6.5
 
 -------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
-- 4.6.0
 
 -------------------------------------------------------------------
 Wed May 10 13:35:34 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.6.1
+Version:        4.6.5
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/OnPanic.rb
+++ b/src/modules/OnPanic.rb
@@ -95,7 +95,7 @@ module Yast
         Ops.get(entry, 0),
         "^/dev/dasd[[:lower:]]+$"
       )
-      is_zfcp = Builtins.regexpmatch(Ops.get(entry, 0), "^/dev/sd[[:lower:]]+$")
+      is_zfcp = Builtins.regexpmatch(Ops.get(entry, 0), "^/dev/(sd[[:lower:]]+|mapper/.*)$")
 
       if is_dasd
         dev = Builtins.add(dev, "DUMP_TYPE", "ccw")
@@ -135,7 +135,7 @@ module Yast
             Ops.get(line, 2) == Ops.get(dev, "DEVICE") ||
             # check for fitting zfcp
             type == "fcp" &&
-                Builtins.regexpmatch(Ops.get(line, 0), "^/dev/sd[[:lower:]]+") &&
+                Builtins.regexpmatch(Ops.get(line, 0), "^/dev/(sd[[:lower:]]+|mapper/)") &&
                 Ops.get(line, 2) == Ops.get(dev, "DEVICE") &&
                 Ops.get(line, 3) == Ops.get(dev, "WWPN") &&
                 Ops.get(line, 4) == Ops.get(dev, "LUN") # check for fitting dasd


### PR DESCRIPTION
Depends on https://build.opensuse.org/package/show/Base:System/s390-tools commit ("mkdump: add support for multipathed zfcp-attached SCSI disks") [patch 7 in SUSE bug 1216257].

## Problem

Users should use multipathing for all zfcp-attached SCSI disks. Since a long time, zipl can write the partition-based zfcpdump standalone dumper boot record to a multipath device. This avoids users having to flush multipath maps or maintain a multipath exception list just for zfcp dump volumes. Always having multipathing for everything also provides redundant access to the dump volume on importing the dump from the volume into a filesystem after the standalone dumper had written the dump.

## Solution

An updated mkdump.pl from SUSE s390-tools understands and lists such multipath devices. Make "yast onpanic" understand /dev/mapper/... multipath devices as better alternative to single path SCSI disks /dev/sd[a-z]+.

Fixes SUSE bug 1020336.

## Testing

- *Tested manually*

## Screenshots

![yast-s390-onpanic-zfcp-multipath-device_](https://github.com/yast/yast-s390/assets/34030961/a7dbaa0a-7ac4-48de-9533-3d6dafcc8897)

@jiribohac @hramrach @hreinecke @mwilck @teclator