### PR TITLE
Mkinitrd removal sp5

### DIFF
--- a/package/yast2-s390.changes
+++ b/package/yast2-s390.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  6 09:00:01 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Replace 'mkinitrd' with dracut (bsc#1220995)
+- 4.5.4
+
+-------------------------------------------------------------------
 Wed May 10 13:35:34 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent crash when the user closes the DASD context menu

--- a/package/yast2-s390.spec
+++ b/package/yast2-s390.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-s390
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2s390/dialogs/mkinitrd.rb
+++ b/src/lib/y2s390/dialogs/mkinitrd.rb
@@ -3,11 +3,11 @@ require "ui/dialog"
 module Y2S390
   module Dialogs
     class Mkinitrd < ::UI::Dialog
-      CMD = "/sbin/mkinitrd".freeze
+      CMD = ["/usr/bin/dracut", "--force"].freeze
 
       def dialog_content
         textdomain "s390"
-        Label(_("Running mkinitrd."))
+        Label(_("Running dracut."))
       end
 
       def self.run
@@ -16,7 +16,7 @@ module Y2S390
 
       def run
         create_dialog
-        Yast::Execute.on_target(CMD)
+        Yast::Execute.on_target(*CMD)
         close_dialog
       end
     end

--- a/src/modules/ZFCPController.rb
+++ b/src/modules/ZFCPController.rb
@@ -152,9 +152,9 @@ module Yast
       if !Mode.installation
         if @disk_configured
           # popup label
-          UI.OpenDialog(Label(_("Running mkinitrd.")))
+          UI.OpenDialog(Label(_("Running dracut.")))
 
-          command = "/sbin/mkinitrd"
+          command = "/usr/bin/dracut --force"
           Builtins.y2milestone("Running command %1", command)
           ret = SCR.Execute(path(".target.bash"), command)
           Builtins.y2milestone("Exit code: %1", ret)


### PR DESCRIPTION
## Problem

`mkinitrd` was replaced by dracut. So calling it ends with error.

- https://bugzilla.suse.com/show_bug.cgi?id=1220995
- https://trello.com/c/eBTGTrPl/3611-3-l3-sles15-sp5-some-mkinitrd-call-still-left-in-yast-s390-dasd


## Solution

Replace properly calls.